### PR TITLE
event handling

### DIFF
--- a/waste/classes/Database.py
+++ b/waste/classes/Database.py
@@ -154,6 +154,7 @@ class Database:
         # Only arrival and service events are logged; other events are
         # currently an intended no-op.
         if isinstance(item, (ArrivalEvent, ServiceEvent)):
+            assert item.is_sealed()
             self.buffer.append(item)
 
             if len(self.buffer) >= BUFFER_SIZE:

--- a/waste/classes/Event.py
+++ b/waste/classes/Event.py
@@ -33,9 +33,6 @@ class Event(ABC):
         class_name = self.__class__.__name__
         return f"{class_name}(time={self.time:.2f}, status={self.status.name})"
 
-    def __lt__(self, other):
-        return self.time < other.time
-
 
 class ServiceEvent(Event):
     """

--- a/waste/classes/Simulator.py
+++ b/waste/classes/Simulator.py
@@ -89,12 +89,12 @@ class Simulator:
         while events and now <= horizon:
             event = events.pop()
 
-            if event.time >= now:
-                now = event.time
-            else:
+            if event.time < now:
                 msg = f"{event} time is before current time {now:.2f}!"
                 logger.error(msg)
                 raise ValueError(msg)
+
+            now = event.time
 
             # First seal the event. This ensures all data that was previously
             # linked to changing objects is made static at their current
@@ -114,14 +114,14 @@ class Simulator:
 
                 logger.debug(f"Service at {container.name} at t = {now:.2f}.")
             elif isinstance(event, ShiftPlanEvent):
-                logger.info(f"Generating shift plan at t = {event.time:.2f}.")
+                logger.info(f"Generating shift plan at t = {now:.2f}.")
                 routes = strategy(self, event)
 
                 for route in routes:
                     id_route = store(route)
                     assert id_route is not None
 
-                    service_time = event.time
+                    service_time = now
                     prev = 0
 
                     for container_idx in route.plan:


### PR DESCRIPTION
the heapqueue does not need a tuple of the objects can be sorted by __lt__. Perhaps we should add to __lt__ that if the times are equal, we sort on object id (or some other property).

"now" is clearer than "time" (for me)

I also prefer to read "events" over "queue". In queueing simulators there is a queue, but that is often not the queue of events. 

using heappop and heappush directly saves a tiny bit of time, and to me it's evident these are functions from heapq anyway. 
